### PR TITLE
Routes refactor

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -30,7 +30,7 @@ var (
 // Handler provides an interface for all api/calls.
 type Handler interface {
 	Status() http.HandlerFunc
-	NewMux() *http.ServeMux
+	Route() *mux.Router
 }
 
 type apiHandler struct {
@@ -64,7 +64,7 @@ func (h *apiHandler) Status() http.HandlerFunc {
 }
 
 // TODO: Break this up into sub routers within the handlers.
-func (h *apiHandler) router() *mux.Router {
+func (h *apiHandler) Route() *mux.Router {
 	r := mux.NewRouter()
 
 	r.HandleFunc("/api/status", h.Status())
@@ -159,13 +159,4 @@ func (h *apiHandler) router() *mux.Router {
 		)).Methods("DELETE")
 
 	return r
-}
-
-// NewMux returns a new http.ServeMux with established routes.
-func (h *apiHandler) NewMux() *http.ServeMux {
-	r := h.router()
-
-	s := http.NewServeMux()
-	s.Handle("/", r)
-	return s
 }

--- a/api/api.go
+++ b/api/api.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// TODO: Syslog formatted log/audit files.
+
 var (
 	// ErrMissingID is returned when you made a call that isn't supported
 	// without an ID in the URI
@@ -65,7 +67,7 @@ func (h *apiHandler) Status() http.HandlerFunc {
 func (h *apiHandler) router() *mux.Router {
 	r := mux.NewRouter()
 
-	r.HandleFunc("/status", h.Status())
+	r.HandleFunc("/api/status", h.Status())
 
 	r.HandleFunc("/api/authenticate", h.authHandler.Authenticate()).Methods("POST")
 

--- a/main.go
+++ b/main.go
@@ -54,12 +54,9 @@ func main() {
 	as := newACMEService(db)
 	go autoRenewal(cs, as)
 
-	apiHandler := newAPIHandler(db)
-
 	// Run http server concurrently
 	// Load routes for the server
-	// TODO: Refactor api to be under an http/ module to allow for non-api type calls.
-	mux := apiHandler.NewMux()
+	mux := NewMux(db)
 
 	s := http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
@@ -67,6 +64,17 @@ func main() {
 	}
 
 	log.Fatal(s.ListenAndServe())
+}
+
+// NewMux returns a new http.ServeMux with established routes.
+func NewMux(db *bolt.DB) *http.ServeMux {
+	apiHandler := newAPIHandler(db)
+
+	r := apiHandler.Route()
+
+	s := http.NewServeMux()
+	s.Handle("/api/", r)
+	return s
 }
 
 func initSecret(db *bolt.DB) {


### PR DESCRIPTION
Depends on PR #26 

DO NOT MERGE BEFORE REBASE

small change to refactor routes so that routing is more composable. Rather than returning a full mux, apiHandler (and uiHandler in the future) return routers for their specific paths (/api vs /ui).