### PR TITLE
Debus/certificate get

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -77,7 +77,7 @@ func (h *apiHandler) Route() *mux.Router {
 	r.HandleFunc("/api/certificate",
 		h.midHandler.Permission(
 			auth.PermCertAdmin,
-			h.certificateHandler.Get(),
+			h.certificateHandler.GetAll(),
 		)).Methods("GET")
 
 	r.HandleFunc("/api/certificate/{id}",

--- a/api/api.go
+++ b/api/api.go
@@ -74,7 +74,7 @@ func (h *apiHandler) Route() *mux.Router {
 	r.HandleFunc("/api/config/superadmin/{id}", h.configHandler.SuperAdmin()).Methods("POST")
 
 	// api/certificate
-	r.HandleFunc("/api/certificate",
+	r.HandleFunc("/api/{certificate:certificate(?:\\/)?}",
 		h.midHandler.Permission(
 			auth.PermCertAdmin,
 			h.certificateHandler.GetAll(),

--- a/api/certificate.go
+++ b/api/certificate.go
@@ -121,7 +121,7 @@ func (h *certHandler) GetAll() http.HandlerFunc {
 			return
 		}
 
-		var crs []*CertResp
+		var crs = make([]*CertResp, 0)
 
 		for _, c := range certs {
 			var lastError string

--- a/api/certificate.go
+++ b/api/certificate.go
@@ -21,6 +21,7 @@ const KeyFileExt = ".key"
 const PemFileExt = ".pem"
 
 type CertificateHandler interface {
+	GetAll() http.HandlerFunc
 	Get() http.HandlerFunc
 	Post() http.HandlerFunc
 	Delete() http.HandlerFunc
@@ -111,55 +112,59 @@ func (h *certHandler) Delete() http.HandlerFunc {
 
 }
 
+func (h *certHandler) GetAll() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		certs, err := h.cs.AllCerts()
+		if err != nil {
+			log.Printf("api CertHandler Get(), GetAllCerts(), %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		var crs []*CertResp
+
+		for _, c := range certs {
+			var lastError string
+			if c.LastError != nil {
+				lastError = c.LastError.Error()
+			}
+			cr := &CertResp{
+				ID:            c.ID,
+				Secret:        c.Secret,
+				CommonName:    c.CommonName,
+				Domains:       c.Domains,
+				CertURL:       c.CertURL,
+				CertStableURL: c.CertStableURL,
+				Expiry:        c.Expiry,
+				RenewAt:       c.RenewAt,
+				Issued:        c.Issued,
+				LastError:     lastError,
+				ACMEEmail:     c.ACMEEmail,
+			}
+			crs = append(crs, cr)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+
+		err = json.NewEncoder(w).Encode(crs)
+		if err != nil {
+			log.Printf("apiCertHandler GET ALL, json.Encode(), %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
 func (h *certHandler) Get() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		id := vars["id"]
 
-		// TODO: Factor out this section into new handler with separate
-		// permissions
-
 		// "/api/certificate/"
 		if id == "" {
-			certs, err := h.cs.AllCerts()
-			if err != nil {
-				log.Printf("api CertHandler Get(), GetAllCerts(), %s", err.Error())
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			var crs []*CertResp
-
-			for _, c := range certs {
-				var lastError string
-				if c.LastError != nil {
-					lastError = c.LastError.Error()
-				}
-				cr := &CertResp{
-					ID:            c.ID,
-					Secret:        c.Secret,
-					CommonName:    c.CommonName,
-					Domains:       c.Domains,
-					CertURL:       c.CertURL,
-					CertStableURL: c.CertStableURL,
-					Expiry:        c.Expiry,
-					RenewAt:       c.RenewAt,
-					Issued:        c.Issued,
-					LastError:     lastError,
-					ACMEEmail:     c.ACMEEmail,
-				}
-				crs = append(crs, cr)
-			}
-
-			w.WriteHeader(http.StatusOK)
-			w.Header().Set("Content-Type", "application/json")
-
-			err = json.NewEncoder(w).Encode(crs)
-			if err != nil {
-				log.Printf("apiCertHandler GET ALL, json.Encode(), %s", err.Error())
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
+			log.Printf("api CertHandler GetCert(), should never have routed here")
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 

--- a/repository/boltdb/certificate.go
+++ b/repository/boltdb/certificate.go
@@ -16,7 +16,7 @@ import (
 )
 
 //Error used internally by Cert(id string). Is not meant to be exposed.
-var certificateNotFound := errors.New("Certificate not found")
+var certificateNotFound = errors.New("Certificate not found")
 
 var certBucket = []byte("certs")
 
@@ -96,7 +96,7 @@ func (cr *certRepository) AllCerts() ([]*model.Certificate, error) {
 		return nil
 	})
 
-	var certs []*model.Certificate
+	var certs = make([]*model.Certificate, 0)
 	for _, ec := range ecerts {
 		var lastError error
 		if ec.LastError != "" {

--- a/repository/boltdb/certificate.go
+++ b/repository/boltdb/certificate.go
@@ -125,8 +125,6 @@ func (cr *certRepository) AllCerts() ([]*model.Certificate, error) {
 	return certs, err
 }
 
-
-
 // Cert takes an id and returns their whole cert object.
 func (cr *certRepository) Cert(id string) (*model.Certificate, error) {
 	ec := &encodedCert{}
@@ -142,7 +140,7 @@ func (cr *certRepository) Cert(id string) (*model.Certificate, error) {
 	})
 
 	if err == certificateNotFound {
-		return nil,nil 
+		return nil, nil
 	}
 
 	var lastError error

--- a/repository/boltdb/certificate.go
+++ b/repository/boltdb/certificate.go
@@ -15,6 +15,9 @@ import (
 	"github.com/go-acme/lego/v3/registration"
 )
 
+//Error used internally by Cert(id string). Is not meant to be exposed.
+var certificateNotFound := errors.New("Certificate not found")
+
 var certBucket = []byte("certs")
 
 var certBuckets = []string{
@@ -122,6 +125,8 @@ func (cr *certRepository) AllCerts() ([]*model.Certificate, error) {
 	return certs, err
 }
 
+
+
 // Cert takes an id and returns their whole cert object.
 func (cr *certRepository) Cert(id string) (*model.Certificate, error) {
 	ec := &encodedCert{}
@@ -129,12 +134,16 @@ func (cr *certRepository) Cert(id string) (*model.Certificate, error) {
 		b := tx.Bucket(certBucket)
 		v := b.Get([]byte(id))
 		if v == nil {
-			return nil
+			return certificateNotFound
 		}
 
 		err := json.Unmarshal(v, &ec)
 		return err
 	})
+
+	if err == certificateNotFound {
+		return nil,nil 
+	}
 
 	var lastError error
 	if ec.LastError != "" {

--- a/repository/boltdb/certificate.go
+++ b/repository/boltdb/certificate.go
@@ -16,7 +16,7 @@ import (
 )
 
 //Error used internally by Cert(id string). Is not meant to be exposed.
-var certificateNotFound = errors.New("Certificate not found")
+var errCertificateNotFound = errors.New("Certificate not found")
 
 var certBucket = []byte("certs")
 
@@ -132,14 +132,14 @@ func (cr *certRepository) Cert(id string) (*model.Certificate, error) {
 		b := tx.Bucket(certBucket)
 		v := b.Get([]byte(id))
 		if v == nil {
-			return certificateNotFound
+			return errCertificateNotFound
 		}
 
 		err := json.Unmarshal(v, &ec)
 		return err
 	})
 
-	if err == certificateNotFound {
+	if err == errCertificateNotFound {
 		return nil, nil
 	}
 


### PR DESCRIPTION
## This PR addresses the following issues: 

Refactor function that does two things into two functions that do one thing each.
Improve behavior when getting an empty list of certificates and when getting a certificate that doesn't exist.

### Context

both the get all certificates (`/api/certificate`) and get certificate (`/api/certificate/{id}`) endpoints are handled by the same function. They should be refactored into two separate functions. Which will also let us set different needed permissions for each endpoint.

Note that this PR also fixes an issue where `/api/certificate/some_id_that_doesnt_exist` would  crash and generate a server error instead of returning a 404.
It also changes the behavior of `/api/certificate` when no certificates exist from returning a JSON null to returning an empty JSON array.

### Approach

Refactor the `certficate.Get` which handles `/api/certificate` and `/api/certificate/{id}` into two separate functions. `certificate.Get` which handles `/api/certificate/{id}` and `certificate.GetAll` which handles `/api/certificate.

### Testing

No unit tests right now. To test that the `/api/certificate/` and `/api/certificate/{id}` endpoints actually go to different functions I just temporarily had the handlers log which function was being called and made sure the correct functions were being called at the right times. 
Also made sure that the responses I got matched the responses I got from those API calls before any code was changed.

### Misc.
