### PR TITLE
Debus/issue 39

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -74,7 +74,7 @@ func (h *apiHandler) Route() *mux.Router {
 	r.HandleFunc("/api/config/superadmin/{id}", h.configHandler.SuperAdmin()).Methods("POST")
 
 	// api/certificate
-	r.HandleFunc("/api/{certificate:certificate(?:\\/)?}",
+	r.HandleFunc("/api/certificate",
 		h.midHandler.Permission(
 			auth.PermCertAdmin,
 			h.certificateHandler.GetAll(),

--- a/main.go
+++ b/main.go
@@ -72,8 +72,8 @@ func removeTrailingSlash(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")
-			next.ServeHTTP(w, r)
 		}
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/ImageWare/TLSential/acme"
 	"github.com/ImageWare/TLSential/api"
@@ -61,10 +62,19 @@ func main() {
 
 	s := http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
-		Handler: mux,
+		Handler: removeTrailingSlash(mux),
 	}
 
 	log.Fatal(s.ListenAndServe())
+}
+
+func removeTrailingSlash(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")
+			next.ServeHTTP(w, r)
+		}
+	})
 }
 
 // NewMux returns a new http.ServeMux with established routes.


### PR DESCRIPTION
## This PR addresses the following issues: 
https://github.com/ImageWare/TLSential/issues/39

### Context

By default the router treats "/somepath/" differently than "/somepath" so we have to use some hacky workarounds to get those urls to route to the same handler. This fixes that issue.

### Approach

All requests are first handled by a function that removes the  trailing slash of the request URL before the request is sent off for its regularly scheduled routing.
The only URL treated specially is "/". The slash isn't removed in this case as it causes an infinite redirect loop do the server redirecting requests with no path to "/" (which we then remove, making the server think the client didn't respond to the redirect request)

### Testing

Made sure all the URLs responded normally. And made sure they responded the same way if I added a slash to the end.

### Misc.

We definitely want to remember to add tests for requests like `/` because the go tests obviously didn't catch the infinite redirect issue.
