### PR TITLE
Serve over Https by default and warn sternly if they don't

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Grab any command line arguments
 	flag.StringVar(&email, "email", "test@example.com", "Email address for Let's Encrypt account")
-	flag.IntVar(&port, "port", 80, "port for webserver to run on")
+	flag.IntVar(&port, "port", 443, "port for webserver to run on")
 	flag.StringVar(&dbFile, "db", "tlsential.db", "filename for boltdb database")
 	flag.BoolVar(&secretReset, "secret-reset", false, "reset the JWT secret - invalidates all API sessions")
 	flag.StringVar(&tlsCert, "tls-cert", "/etc/pki/tlsential.crt", "file path for tls certificate")


### PR DESCRIPTION
## This PR addresses the following issues: 
No current issue, but no support for HTTPS as is.

### Context

Currently you cannot serve TLSential over https. 

### Approach

Add a command line flag to allow for NON https and default to serve over https with default crt/key filepaths. 

### Testing

Start in non-https so I could use it to create a cert for itself, once done and downloaded, restart and use those newly minted certs. All worked, and all command line flags worked. 

### Misc.

Will want to follow this up to make it easier to bootstrap TLS ala #47 
