### PR TITLE
Add some basic server and TLS config. When running in HTTPS mode make…

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 	var tlsCert string
 	var tlsKey string
 	var noHTTPS bool
+	var noHTTPRedirect bool
 
 	// Grab any command line arguments
 	flag.StringVar(&email, "email", "test@example.com", "Email address for Let's Encrypt account")
@@ -43,6 +44,7 @@ func main() {
 	flag.StringVar(&tlsCert, "tls-cert", "/etc/pki/tlsential.crt", "file path for tls certificate")
 	flag.StringVar(&tlsKey, "tls-key", "/etc/pki/tlsential.key", "file path for tls private key")
 	flag.BoolVar(&noHTTPS, "no-https", false, "flag to run over http (HIGHLY INSECURE)")
+	flag.BoolVar(&noHTTPRedirect, "no-http-redirect", false, "flag to not redirect HTTP requests to HTTPS")
 
 	flag.Parse()
 
@@ -121,9 +123,9 @@ func main() {
 			}),
 		}
 
-		go func() {
-			log.Print(httpSrv.ListenAndServe())
-		}()
+		if !noHTTPRedirect {
+			go func() { log.Fatal(httpSrv.ListenAndServe()) }()
+		}
 
 		log.Fatal(s.ListenAndServeTLS(tlsCert, tlsKey))
 	}

--- a/main.go
+++ b/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"crypto/rand"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/ImageWare/TLSential/acme"
 	"github.com/ImageWare/TLSential/api"
@@ -31,7 +33,7 @@ func main() {
 	var secretReset bool
 	var tlsCert string
 	var tlsKey string
-	var noHttps bool
+	var noHTTPS bool
 
 	// Grab any command line arguments
 	flag.StringVar(&email, "email", "test@example.com", "Email address for Let's Encrypt account")
@@ -40,7 +42,7 @@ func main() {
 	flag.BoolVar(&secretReset, "secret-reset", false, "reset the JWT secret - invalidates all API sessions")
 	flag.StringVar(&tlsCert, "tls-cert", "/etc/pki/tlsential.crt", "file path for tls certificate")
 	flag.StringVar(&tlsKey, "tls-key", "/etc/pki/tlsential.key", "file path for tls private key")
-	flag.BoolVar(&noHttps, "no-https", false, "flag to run over http (HIGHLY INSECURE)")
+	flag.BoolVar(&noHTTPS, "no-https", false, "flag to run over http (HIGHLY INSECURE)")
 
 	flag.Parse()
 
@@ -66,16 +68,63 @@ func main() {
 	// Load routes for the server
 	mux := NewMux(db)
 
-	s := http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: removeTrailingSlash(mux),
+	tlsConfig := &tls.Config{
+		// Causes servers to use Go's default ciphersuite preferences,
+		// which are tuned to avoid attacks. Does nothing on clients.
+		PreferServerCipherSuites: true,
+		// Only use curves which have assembly implementations
+		CurvePreferences: []tls.CurveID{
+			tls.CurveP256,
+			tls.X25519, // Go 1.8 only
+		},
+		MinVersion: tls.VersionTLS12,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, // Go 1.8 only
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,   // Go 1.8 only
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+
+			// Best disabled, as they don't provide Forward Secrecy,
+			// but might be necessary for some clients
+			// tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			// tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		},
 	}
 
-	if noHttps {
+	s := http.Server{
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+		Addr:         fmt.Sprintf(":%d", port),
+		Handler:      removeTrailingSlash(mux),
+		TLSConfig:    tlsConfig,
+	}
+
+	if noHTTPS {
 		fmt.Println("*** WARNING ***")
 		fmt.Println("* It is extremely unsafe to use this app without proper HTTPS *")
 		log.Fatal(s.ListenAndServe())
 	} else {
+
+		//Create an HTTP server that exists solely to redirect to https
+		httpSrv := http.Server{
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
+			IdleTimeout:  5 * time.Second,
+			// Addr:         ":8081",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("Connection", "close")
+				url := "https://" + req.Host + req.URL.String()
+				http.Redirect(w, req, url, http.StatusMovedPermanently)
+			}),
+		}
+
+		go func() {
+			log.Print(httpSrv.ListenAndServe())
+		}()
+
 		log.Fatal(s.ListenAndServeTLS(tlsCert, tlsKey))
 	}
 


### PR DESCRIPTION
… sure to also try to spawn an HTTP server that just redirects to HTTPS

## This PR addresses the following issues: 
https://github.com/ImageWare/TLSential/issues/45

### Context

The server has the default TLS configuration and has no timeouts set.
Which means connections can't timeout and can hang forever.

### Approach

Set some best guess timeouts for reading, writing, and idle time. Set up basic TLS config.
When running in HTTPS mode, spawn an HTTP server whose sole purpose is to redirect HTTP requests to their HTTPS version.

### Testing

Hit the server in HTTP mode to make sure it gets told to redirect. Haven't actually wrote anything that would connect and hang to test timeouts. Might be a good TODO.
