### PR TITLE
Debus/client cache

### DIFF
--- a/api/certificate.go
+++ b/api/certificate.go
@@ -61,6 +61,7 @@ type CertResp struct {
 	Issued        bool
 	LastError     string
 	ACMEEmail     string
+	ModTime       time.Time
 }
 
 // TODO: Add validation function to make sure domains are actual domains.
@@ -142,6 +143,7 @@ func (h *certHandler) GetAll() http.HandlerFunc {
 				Issued:        c.Issued,
 				LastError:     lastError,
 				ACMEEmail:     c.ACMEEmail,
+				ModTime:       c.ModTime,
 			}
 			crs = append(crs, cr)
 		}
@@ -200,6 +202,7 @@ func (h *certHandler) Get() http.HandlerFunc {
 			Issued:        c.Issued,
 			LastError:     lastError,
 			ACMEEmail:     c.ACMEEmail,
+			ModTime:       c.ModTime,
 		}
 
 		w.WriteHeader(http.StatusOK)
@@ -272,6 +275,7 @@ func (h *certHandler) Post() http.HandlerFunc {
 			Issued:        c.Issued,
 			LastError:     "",
 			ACMEEmail:     c.ACMEEmail,
+			ModTime:       c.ModTime,
 		}
 
 		w.WriteHeader(http.StatusCreated)
@@ -319,7 +323,7 @@ func (h *certHandler) GetCert() http.HandlerFunc {
 			return
 		}
 
-		modtime := time.Now()
+		modtime := c.ModTime
 		filename := fmt.Sprintf("%s%s", c.CommonName, CertFileExt)
 		cd := fmt.Sprintf("attachment; filename=%s", filename)
 
@@ -358,7 +362,7 @@ func (h *certHandler) GetIssuer() http.HandlerFunc {
 			return
 		}
 
-		modtime := time.Now()
+		modtime := c.ModTime
 		filename := fmt.Sprintf("%s%s", c.CommonName, IssuerCertFileExt)
 		cd := fmt.Sprintf("attachment; filename=%s", filename)
 
@@ -405,7 +409,7 @@ func (h *certHandler) GetPrivkey() http.HandlerFunc {
 			return
 		}
 
-		modtime := time.Now()
+		modtime := c.ModTime
 		filename := fmt.Sprintf("%s%s", c.CommonName, KeyFileExt)
 		cd := fmt.Sprintf("attachment; filename=%s", filename)
 

--- a/auth.sh
+++ b/auth.sh
@@ -6,6 +6,6 @@ HOST=$3
 
 BASIC=$(echo -n "$ID:$PASS" | base64)
  
-JWT=$(curl -s -X POST $HOST/api/authenticate -H "Authorization: Basic $BASIC")
+JWT=$(curl -s -k -X POST $HOST/api/authenticate -H "Authorization: Basic $BASIC")
 
 echo $JWT

--- a/model/certificate.go
+++ b/model/certificate.go
@@ -60,6 +60,8 @@ type Certificate struct {
 
 	LastError error
 
+	ModTime time.Time
+
 	ACMEEmail        string
 	ACMERegistration *registration.Resource
 	ACMEKey          *ecdsa.PrivateKey

--- a/repository/boltdb/certificate.go
+++ b/repository/boltdb/certificate.go
@@ -51,6 +51,8 @@ type encodedCert struct {
 
 	LastError string
 
+	ModTime time.Time
+
 	ACMEEmail        string
 	ACMERegistration *registration.Resource
 
@@ -119,6 +121,7 @@ func (cr *certRepository) AllCerts() ([]*model.Certificate, error) {
 			ACMEEmail:         ec.ACMEEmail,
 			ACMERegistration:  ec.ACMERegistration,
 			ACMEKey:           decode(ec.ACMEKey),
+			ModTime:           ec.ModTime,
 		}
 		certs = append(certs, c)
 	}
@@ -164,6 +167,7 @@ func (cr *certRepository) Cert(id string) (*model.Certificate, error) {
 		ACMEEmail:         ec.ACMEEmail,
 		ACMERegistration:  ec.ACMERegistration,
 		ACMEKey:           decode(ec.ACMEKey),
+		ModTime:           ec.ModTime,
 	}
 	return c, err
 }
@@ -174,6 +178,7 @@ func (cr *certRepository) SaveCert(c *model.Certificate) error {
 	if c.LastError != nil {
 		lastError = c.LastError.Error()
 	}
+	c.ModTime = time.Now()
 	ec := &encodedCert{
 		ID:                c.ID,
 		Secret:            c.Secret,
@@ -191,6 +196,7 @@ func (cr *certRepository) SaveCert(c *model.Certificate) error {
 		ACMEEmail:         c.ACMEEmail,
 		ACMERegistration:  c.ACMERegistration,
 		ACMEKey:           encode(c.ACMEKey),
+		ModTime:           c.ModTime,
 	}
 	err := cr.DB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(certBucket)


### PR DESCRIPTION
### Context

Cert objects are rarely modified, so clients are easily able to cache them. This PR adds a ModTime field to cert objects which is updated everytime the cert is written to the database. 
When we respond to requests for `/api/certificate/{id}/(privkey|issuer|cert)` we set the modtime and the server object will automatically set a `Last-Modified` header. 
as well as handles Range requests properly, sets the MIME type, and handles If-Match, If-Unmodified-Since, If-None-Match, If-Modified-Since,
 and If-Range requests.

### Testing

Made requests and made sure the the `last-modified` header was set, as well as making sure it returned a 304 if I set `If-Modified-Since` to a time after `last-modified`

### Misc.

Not sure if we want to ServeContent with the GetCertificate and GetAllCertificates methods, so that we get this behavior?
Although for GetAllCertificates we'd probably have to track the newest ModTime while looping through the certs
