### PR TITLE
Cb/14 domain parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,6 @@ require (
 	github.com/segmentio/ksuid v1.0.2
 	go.etcd.io/bbolt v1.3.4
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 // indirect
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,7 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5 h1:WQ8q63x+f/zpC8Ac1s9wLElVoHhm32p6tudrU72n1QA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/model/certificate.go
+++ b/model/certificate.go
@@ -22,8 +22,6 @@ import (
 
 const CADirURL = "https://acme-v02.api.letsencrypt.org/directory"
 
-const domainRegex = `^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`
-
 // DefaultRenewAt is the number of days before expiration a cert should be
 // renewed at.
 const DefaultRenewAt = 30

--- a/model/certificate.go
+++ b/model/certificate.go
@@ -85,7 +85,8 @@ func NewCertificate(domains []string, email string) (*Certificate, error) {
 
 	var domainValidator = idna.New(idna.ValidateForRegistration())
 
-	// iterate through each domain and check against the regex from https://stackoverflow.com/a/30007882
+	// iterate through each domain and validate it, if any of them fail we fail the
+	// function with the appropriate error
 	for _, domain := range domains {
 
 		url, _ := url.Parse(domain)

--- a/model/certificate.go
+++ b/model/certificate.go
@@ -82,9 +82,8 @@ func NewCertificate(domains []string, email string) (*Certificate, error) {
 		return nil, ErrInvalidDomains
 	}
 
-	domainsValidated := containsOnlyValidDomains(domains)
-
-	if !domainsValidated {
+	// Validate domains in list
+	if !ValidDomains(domains) {
 		return nil, ErrInvalidDomains
 	}
 
@@ -120,6 +119,7 @@ func NewCertificate(domains []string, email string) (*Certificate, error) {
 		return nil, err
 	}
 
+	// TODO: Move this to acme Service so we can mock here
 	reg, err := client.Registration.Register(registration.RegisterOptions{TermsOfServiceAgreed: true})
 	if err != nil {
 		return nil, err
@@ -144,9 +144,10 @@ func (c *Certificate) GetPrivateKey() crypto.PrivateKey {
 	return c.ACMEKey
 }
 
-// validateDomains is used to validate that the passed domains set includes only
-// valid domains (ie example.com or *.example.com)
-func containsOnlyValidDomains(domains []string) bool {
+// ValidDomains is used to validate that the passed domains set includes only
+// valid domains (ie example.com or *.example.com). Returns bool designating
+// whether or not they are ALL valid domains.
+func ValidDomains(domains []string) bool {
 
 	var domainValidator = idna.New(idna.MapForLookup(), idna.StrictDomainName(false))
 
@@ -157,7 +158,7 @@ func containsOnlyValidDomains(domains []string) bool {
 		url, _ := url.Parse(domain)
 
 		// schemes are disallowed, this just checks if the domain is a valid URL
-		// // and if so if it's got a non-empty scheme
+		// and if so if it's got a non-empty scheme
 		if url != nil && len(url.Scheme) != 0 {
 			return false
 		}

--- a/model/certificate_test.go
+++ b/model/certificate_test.go
@@ -34,13 +34,13 @@ func TestNewCertificate(t *testing.T) {
 		},
 		{
 			"wildcard domain",
-			[]string{"*.google.com"},
+			[]string{"*.example.com"},
 			"test@notexample.com",
 			"",
 		},
 		{
 			"bad wildcard domain",
-			[]string{"https://*.google.com"},
+			[]string{"https://*.example.com"},
 			"test@notexample.com",
 			ErrInvalidDomains.Error(),
 		},
@@ -130,6 +130,45 @@ func TestNewCertificate(t *testing.T) {
 				t.Error("acme key should not be nil")
 			}
 		})
+	}
+}
+
+func TestContainsOnlyValidDomains(t *testing.T) {
+
+	// happy path
+	domains := []string{"example.com", "example2.com"}
+
+	if !containsOnlyValidDomains(domains) {
+		t.Error("example.com should be a valid domain")
+	}
+
+	// schemes are unacceptable
+	domains = []string{"https://example.com"}
+
+	if containsOnlyValidDomains(domains) {
+		t.Error("schemes are invalid domain names for us")
+	}
+
+	// good wildcard
+	domains = []string{"*.example.com"}
+
+	if !containsOnlyValidDomains(domains) {
+		t.Error("Wildcard domains are valid")
+	}
+
+	// schemes and wildcards are just out entirely
+	domains = []string{"https://*.example.com"}
+
+	if containsOnlyValidDomains(domains) {
+		t.Error("schemes and wildcards are invalid domain names for us")
+	}
+
+	// several checks with a failure just at the end
+	domains = []string{"www.domain.com", "tests.goodstuff", "example.example",
+		"*.wildcarddomainz.com", "https://abaddomainnameexamplebecauseithasaschemeinit.com"}
+
+	if containsOnlyValidDomains(domains) {
+		t.Error("the last item was definitely bad but it was accepted anyway")
 	}
 }
 

--- a/model/certificate_test.go
+++ b/model/certificate_test.go
@@ -133,41 +133,48 @@ func TestNewCertificate(t *testing.T) {
 	}
 }
 
-func TestContainsOnlyValidDomains(t *testing.T) {
+func TestValidDomains(t *testing.T) {
 
 	// happy path
 	domains := []string{"example.com", "example2.com"}
 
-	if !containsOnlyValidDomains(domains) {
+	if !ValidDomains(domains) {
 		t.Error("example.com should be a valid domain")
 	}
 
 	// schemes are unacceptable
 	domains = []string{"https://example.com"}
 
-	if containsOnlyValidDomains(domains) {
+	if ValidDomains(domains) {
 		t.Error("schemes are invalid domain names for us")
 	}
 
 	// good wildcard
 	domains = []string{"*.example.com"}
 
-	if !containsOnlyValidDomains(domains) {
+	if !ValidDomains(domains) {
 		t.Error("Wildcard domains are valid")
 	}
 
 	// schemes and wildcards are just out entirely
 	domains = []string{"https://*.example.com"}
 
-	if containsOnlyValidDomains(domains) {
+	if ValidDomains(domains) {
 		t.Error("schemes and wildcards are invalid domain names for us")
+	}
+
+	// schemes and wildcards are just out entirely
+	domains = []string{"many.sub.domains.example.com"}
+
+	if !ValidDomains(domains) {
+		t.Error("multiple subdomains don't work")
 	}
 
 	// several checks with a failure just at the end
 	domains = []string{"www.domain.com", "tests.goodstuff", "example.example",
 		"*.wildcarddomainz.com", "https://abaddomainnameexamplebecauseithasaschemeinit.com"}
 
-	if containsOnlyValidDomains(domains) {
+	if ValidDomains(domains) {
 		t.Error("the last item was definitely bad but it was accepted anyway")
 	}
 }

--- a/model/certificate_test.go
+++ b/model/certificate_test.go
@@ -32,6 +32,18 @@ func TestNewCertificate(t *testing.T) {
 			"test@example.com",
 			"acme: error: 400 :: POST :: https://acme-v02.api.letsencrypt.org/acme/new-acct :: urn:ietf:params:acme:error:invalidEmail :: Error creating new account :: invalid contact domain. Contact emails @example.com are forbidden, url: ",
 		},
+		{
+			"wildcard domain",
+			[]string{"*.google.com"},
+			"test@notexample.com",
+			"",
+		},
+		{
+			"bad wildcard domain",
+			[]string{"https://*.google.com"},
+			"test@notexample.com",
+			ErrInvalidDomains.Error(),
+		},
 	}
 
 	for _, ct := range certTests {

--- a/repository/boltdb/certificate_test.go
+++ b/repository/boltdb/certificate_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCertificate(t *testing.T) {
-	db, err := bolt.Open("test.db", 0666, nil)
+	db, err := bolt.Open(TestDBPath, 0666, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## This PR addresses the following issues: 

Domain validation in the `NewCertificate` function.

### Context

We need to support validation for domains, so callers to the API can receive better error handling.

### Approach

Iterates through each of the given domain names and checks that they're a valid domain, and that they have an empty scheme.

### Testing

Added 2 new test cases for wildcard and scheme-containing domains.

### Misc.

I get a 429 from ACME when running the unit tests because it failed the domain check for schemes too often, might be a good move to eventually mock out ACME and be able to make this call without actually performing the registration.
