### PR TITLE
Fix tests by defering db close

### DIFF
--- a/repository/boltdb/certificate_test.go
+++ b/repository/boltdb/certificate_test.go
@@ -12,6 +12,8 @@ func TestCertificate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer db.Close()
+
 	r, err := NewCertificateRepository(db)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Accidentally broke tests by not closing the DB, other tests were waiting for the file to unlock