### PR TITLE
Add logout and csrf protection.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-acme/lego v2.7.2+incompatible
 	github.com/go-acme/lego/v3 v3.5.0
+	github.com/gorilla/csrf v1.7.0
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/sessions v1.2.0
 	github.com/mikespook/gorbac v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/gophercloud/gophercloud v0.3.0 h1:6sjpKIpVwRIIwmcEGp+WwNovNsem+c+2vm6
 github.com/gophercloud/gophercloud v0.3.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/csrf v1.7.0 h1:mMPjV5/3Zd460xCavIkppUdvnl5fPXMpv2uz2Zyg7/Y=
+github.com/gorilla/csrf v1.7.0/go.mod h1:+a/4tCmqhG6/w4oafeAZ9pEa3/NZOWYVbD9fV0FwIQA=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
@@ -259,6 +261,8 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/main.go
+++ b/main.go
@@ -81,12 +81,9 @@ func main() {
 	// Load routes for the server
 	var mux http.Handler
 
-	// Allow for CSRF to "pass" even over non-https. Hence, unsafe.
-	if noHTTPS {
-		mux = NewMux(true, db)
-	} else {
-		mux = NewMux(false, db)
-	}
+	// Pass bool for HTTPS as it specifically needs to be disabled in CSRF
+	// protection if no HTTPS.
+	mux = NewMux(noHTTPS, db)
 
 	if debug {
 		//For now the only middleware that debug adds is basic request logging.
@@ -94,6 +91,7 @@ func main() {
 		mux = chainMiddleware(mux, requestLoggingMiddleWare)
 	}
 
+	// Thanks Filippo
 	tlsConfig := &tls.Config{
 		// Causes servers to use Go's default ciphersuite preferences,
 		// which are tuned to avoid attacks. Does nothing on clients.
@@ -101,14 +99,14 @@ func main() {
 		// Only use curves which have assembly implementations
 		CurvePreferences: []tls.CurveID{
 			tls.CurveP256,
-			tls.X25519, // Go 1.8 only
+			tls.X25519, // Go 1.8+ only
 		},
 		MinVersion: tls.VersionTLS12,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, // Go 1.8 only
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,   // Go 1.8 only
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, // Go 1.8+ only
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,   // Go 1.8+ only
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -14,7 +14,6 @@
           <a class="float-right mt-1" href="certificates">View certificates</a>
         </div>
       </div>
-      <form class="needs-validation pt-2" novalidate>
         <div class="row">
           <div class="col-md-6 col-12 mb-3">
             <div title="Total certificates" data-toggle="tooltip" data-placement="bottom">

--- a/ui/templates/layout.html
+++ b/ui/templates/layout.html
@@ -5,19 +5,25 @@
 {{template "head" .Head}}
 
 <body>
-    <header class="navbar navbar-expand-lg flex-column flex-md-row navbar-dark tls-navbar-dark">
+    <header class="navbar navbar-expand-lg flex-column flex-md-row navbar-light">
         <a class="navbar-brand" href='#home'>
             <img src="/static/images/tlsential_web_logo.svg" alt="TLSential" height="42">
         </a>
         <div class="collapse navbar-collapse" id="navbar">
             <div class="navbar-nav" id="boq-navbar-links">
-                <a class="nav-item nav-link" href="dashboard.html">Dashboard</a>
+                <a class="nav-item nav-link" href="/ui/dashboard">Dashboard</a>
+            </div>
+            <div class="navbar-nav" id="boq-navbar-links">
+                <form action="/ui/logout" method="POST">
+                 {{ .CSRFField }}
+                <button class="nav-item nav-link" type="submit">Logout</label>
+                </form>
             </div>
         </div>
     </header>
     <div class="container">
         <main class="content" role="main">
-            {{ template "content" }}
+            {{ template "content" .C }}
         </main>
     </div>
 

--- a/ui/templates/login.html
+++ b/ui/templates/login.html
@@ -34,8 +34,9 @@
               </div>
               <button class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
             </div>
-            {{if .Error ne ""}}{{.Error}}{{end}}
+            {{if ne .Error ""}}{{.Error}}{{end}}
             <p class="text-center mt-4 mb-3 text-muted">&copy; ImageWare Systems Inc. 2020</p>
+            {{ .CSRFField }}
           </form>
         </div>
       </div>

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -50,20 +50,13 @@ func (h *uiHandler) Route(unsafe bool) http.Handler {
 	}
 
 	var CSRF func(http.Handler) http.Handler
-	if unsafe {
-		CSRF = csrf.Protect(
-			key,
-			csrf.SameSite(csrf.SameSiteStrictMode),
-			csrf.FieldName("csrf_token"),
-			csrf.Secure(false),
-		)
-	} else {
-		CSRF = csrf.Protect(
-			key,
-			csrf.SameSite(csrf.SameSiteStrictMode),
-			csrf.FieldName("csrf_token"),
-		)
-	}
+
+	CSRF = csrf.Protect(
+		key,
+		csrf.SameSite(csrf.SameSiteStrictMode),
+		csrf.FieldName("csrf_token"),
+		csrf.Secure(!unsafe), // If unsafe, we pass in FALSE for secure.
+	)
 
 	r := mux.NewRouter()
 	r.HandleFunc("/ui/dashboard", h.Authenticated(h.Dashboard()))


### PR DESCRIPTION
## This PR addresses the following issues: 
Fixes #58 

### Context

Need a way to log out of the website. Also, no csrf was being used yet.

### Approach

This adds a logout handler and also gorilla csrf.

### Testing

Login, logout, try and hit /ui/dashboard while logged out, hit /ui/login while already logged in, etc.

### Misc.

UI could use some help, @domshyra ;)
