### PR TITLE
Add client address to the per-request logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,12 +160,22 @@ func chainMiddleware(handler http.Handler, middlewares ...middleware) http.Handl
 	return handler
 }
 
+func getIP(r *http.Request) string {
+	addr := r.Header.Get("X-FORWARDED-FOR")
+	if addr == "" {
+		addr = r.RemoteAddr
+	}
+	return addr
+}
+
 func requestLoggingMiddleWare(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
 		//Defer in case one of the handlers down the line calls panic
-		defer func() { log.Println(r.Method, r.URL.Path, time.Since(start)) }()
+		defer func() {
+			log.Println(getIP(r), r.Method, r.URL.Path, time.Since(start))
+		}()
 
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
## This PR addresses the following issues: 

https://github.com/ImageWare/TLSential/issues/64

### Approach

For every request we look if the `X-FORWARDED-FOR` header is set and use that, falling back to the `http.Request.RemoteAddr` field if the header isn't set.
We then add that address to the log for the request.

### Testing

requests with curl. Both with and without the `X-FORWARDED-FOR` header.
