### PR TITLE
Make Cert Secrets one time use.

### DIFF
--- a/api/certificate.go
+++ b/api/certificate.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ImageWare/TLSential/acme"
+	"github.com/ImageWare/TLSential/auth"
 	"github.com/ImageWare/TLSential/certificate"
 	"github.com/ImageWare/TLSential/model"
 
@@ -406,6 +407,15 @@ func (h *certHandler) GetPrivkey() http.HandlerFunc {
 			// https://tools.ietf.org/html/rfc7235#section-3.1
 			w.Header().Set("WWW-Authenticate", "Secret")
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+
+		// Secrets are one time use for downloading PrivKeys.
+		c.Secret = auth.NewPassword()
+		err = h.cs.SaveCert(c)
+		if err != nil {
+			log.Printf("apiCertHandler GET PrivKey, SaveCert(), %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
## This PR addresses the following issues: 
Fixes #74 

### Context

Previously, Cert secrets didn't change which increases possible exposure. Command line history, for example, could divulge the secret.

### Approach

Every time a secret is used to download the privkey, the secret is reset and will need to be retrieved again for future use. This should be okay because any future need for downloading the privkey will require manual intervention on the endpoint anyways.

### Testing

Try downloading the cert twice in a row with the same secret.

