### PR TITLE
Change response code for Super Admin request to 400

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -52,6 +52,11 @@ func (h *configHandler) SuperAdmin() http.HandlerFunc {
 		// Try and create new SA
 		u, p, err := h.cs.CreateSuperAdmin(id)
 		if err != nil {
+			if err == service.ErrSuperAdminExists {
+				log.Printf("SuperAdmin, CreateSuperAdmin(), attempt to create second Super Admin")
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 			log.Printf("SuperAdmin, CreateSuperAdmin(), %s", err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
### Context

Super Admins can only be created once unless the server is restarted with the "reset superadmin" flag set. If you were to make a follow up request to create a super admin when one already exists, the server returned 500 which is not meaningful.

### Approach

Change response code to 400 for the error  case of a SA already existing.

### Testing

attempt to make 2 SAs